### PR TITLE
Made namespaces less granular

### DIFF
--- a/Runtime/Actions/Base/BaseDebugAction.cs
+++ b/Runtime/Actions/Base/BaseDebugAction.cs
@@ -4,7 +4,7 @@ using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Base class for all debug action

--- a/Runtime/Actions/Base/FluentAction.cs
+++ b/Runtime/Actions/Base/FluentAction.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Base debug action class that has common fluent methods

--- a/Runtime/Actions/DebugActionButton.cs
+++ b/Runtime/Actions/DebugActionButton.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Button action will be represented as a simple button in the debug menu

--- a/Runtime/Actions/DebugActionEnum.cs
+++ b/Runtime/Actions/DebugActionEnum.cs
@@ -3,7 +3,7 @@ using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Enum action will be represented as a button selector in the debug menu, triggering the action will cycle the value

--- a/Runtime/Actions/DebugActionFlag.cs
+++ b/Runtime/Actions/DebugActionFlag.cs
@@ -2,7 +2,7 @@ using System;
 using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Flag action will be represented as a button selector in the debug menu, triggering the action will cycle the value and notify the flag listener, if `isPersistence` is true, the value will also be updated to PlayerPrefs.

--- a/Runtime/Actions/DebugActionInput.cs
+++ b/Runtime/Actions/DebugActionInput.cs
@@ -7,7 +7,7 @@ using BennyKok.RuntimeDebug.Systems;
 using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Input action will be represented as a button in the debug menu, once triggered, an input field will popup, the input will be split by space and parse using regex, if more than one paramenters is defined and you have space between your string, use double quote for string during input.

--- a/Runtime/Actions/DebugActionToggle.cs
+++ b/Runtime/Actions/DebugActionToggle.cs
@@ -4,7 +4,7 @@ using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 using UnityEngine.Events;
 
-namespace BennyKok.RuntimeDebug.Actions
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// Toggle action will be represented as a button toggle in the debug menu with on/off status

--- a/Runtime/Attributes/DebugActionAttribute.cs
+++ b/Runtime/Attributes/DebugActionAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace BennyKok.RuntimeDebug.Attributes
+namespace BennyKok.RuntimeDebug
 {
     [Serializable]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]

--- a/Runtime/Components/Actions/DebugActionAutoHandler.cs
+++ b/Runtime/Components/Actions/DebugActionAutoHandler.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System;
 using BennyKok.RuntimeDebug.Data;
-using BennyKok.RuntimeDebug.Attributes;
+//using BennyKok.RuntimeDebug.Attributes;
 
 #if UNITY_EDITOR
 using UnityEditorInternal;

--- a/Runtime/Data/ReflectedActionData.cs
+++ b/Runtime/Data/ReflectedActionData.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Reflection;
 using BennyKok.RuntimeDebug.Actions;
-using BennyKok.RuntimeDebug.Attributes;
+//using BennyKok.RuntimeDebug.Attributes;
 
 namespace BennyKok.RuntimeDebug.Data
 {

--- a/Runtime/Systems/RuntimeDebugSystem.cs
+++ b/Runtime/Systems/RuntimeDebugSystem.cs
@@ -10,7 +10,7 @@ using BennyKok.RuntimeDebug.DebugInput;
 using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 
-namespace BennyKok.RuntimeDebug.Systems
+namespace BennyKok.RuntimeDebug
 {
     /// <summary>
     /// The singleton system class to handle the lifecycle of all runtime debug actions, loading of the settings ScriptableObject and also the communication between the system and UIHandler

--- a/Runtime/Systems/RuntimeDebugSystem.cs
+++ b/Runtime/Systems/RuntimeDebugSystem.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BennyKok.RuntimeDebug.Actions;
-using BennyKok.RuntimeDebug.Attributes;
+//using BennyKok.RuntimeDebug.Attributes;
 using BennyKok.RuntimeDebug.Components.UI;
 using BennyKok.RuntimeDebug.Data;
 using BennyKok.RuntimeDebug.DebugInput;
+using BennyKok.RuntimeDebug.Systems;
 using BennyKok.RuntimeDebug.Utils;
 using UnityEngine;
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "com.bennykok.runtime-debug-action",
+  "name": "com.ennerfelt.runtime-debug",
   "displayName": "Runtime Debug Action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Runtime debug action with \"out of the box just works\" ui debug menu to speed up your game development cycle.",
-  "author": "BennyKok",
+  "author": "Alex Ennerfelt",
   "dependencies": {
     "com.unity.textmeshpro": "3.0.1"
   }


### PR DESCRIPTION
Changed the namespaces so that the classes that are being accessed all the time are within one namespace. Mainly DebugActionAttribute, RuntimeDebugSystem, and all Actons. 

It's one of the best tools that can be found for Unity Projects, the need to add three using declarations is the only thing that is **mildly** annoying. 
